### PR TITLE
Cell training

### DIFF
--- a/models/networks.py
+++ b/models/networks.py
@@ -309,19 +309,23 @@ def cal_gradient_penalty(netD, real_data, fake_data, device, type='mixed', const
 
 
 class Cell(nn.Module):
-    def __init__(self, layer_types, nr_layer, weights, dim):
+    def __init__(self, layer_types, nr_layer, weights, dim, device):
         super(Cell, self).__init__()
 
         self.module_list = nn.ModuleList()
         self.cell_weights = weights
+        self.nr_layer = nr_layer
+        self.device = device
+        self.layer_types = layer_types
 
-        for i in range(nr_layer):
+        for i in range(self.nr_layer):
             for layer_type in layer_types:
                 self.module_list.append(self.layer_type_encoder(layer_type, dim))
 
     
     def forward(self, input):
         values = [input]
+        count = 0
 
         for i in range(self.nr_layer):
             print(len(values))
@@ -388,7 +392,7 @@ class NASGenerator(nn.Module):
         self.cell_weights = self.get_layer_weights(self.n_layers_cell, len(self.layer_types))
 
         for i in range(self.n_blocks):
-            self.module_list.append(Cell(self.layer_types, self.n_layers_cell, self.cell_weights, mult*ngf))
+            self.module_list.append(Cell(self.layer_types, self.n_layers_cell, self.cell_weights, mult*ngf, self.device))
 
         upsampling = []
         for i in range(n_downsampling):  # add upsampling layers

--- a/models/networks.py
+++ b/models/networks.py
@@ -439,7 +439,7 @@ class NASGenerator(nn.Module):
     def get_layer_weights(self, n_blocks, nr_layer_types):
         cell_weights = F.softmax(torch.ones([n_blocks, nr_layer_types]), dim=-1)
         cell_weights = cell_weights.to(torch.float64)
-        cell_weights = nn.Parameter(cell_weights, requires_grad=True)
+        cell_weights = nn.Parameter(cell_weights, requires_grad=False)
         return cell_weights
 
 

--- a/models/networks.py
+++ b/models/networks.py
@@ -341,21 +341,30 @@ class Cell(nn.Module):
 
     def layer_type_encoder(self, layer_type, dim):
         match layer_type:
-            case 'conv_2d':
+            case 'ReflectionPad2d_Conv2d':
                 return nn.Sequential(
+                    nn.ReflectionPad2d(1),
                     nn.Conv2d(dim, dim, kernel_size=3, padding='same', bias=False),
-                    nn.ReLU()
+                    # nn.ReLU()
                 )
-            case 'pool_2d':
-                return nn.Sequential(
-                    nn.MaxPool2d(3, 1, padding=1),
-                    nn.ReLU()
-                )
-            case 'linear':
-                return nn.Sequential(
-                    Resized_Linear(dim, dim, False),
-                    nn.ReLU()
-                )
+            case 'Conv2d':
+                return nn.Conv2d(dim, dim, 3, 1, 1)
+            # case 'pool_2d':
+            #     return nn.Sequential(
+            #         nn.MaxPool2d(3, 1, padding=1),
+            #         nn.ReLU()
+            #     )
+            # case 'linear':
+            #     return nn.Sequential(
+            #         Resized_Linear(dim, dim, False),
+            #         nn.ReLU()
+            #     )
+            case 'BatchNorm2d':
+                return nn.BatchNorm2d(dim)
+            case 'InstanceNorm2d':
+                return nn.InstanceNorm2d(dim)
+            case 'ReLU':
+                return nn.ReLU(inplace=True)
 
 
 
@@ -368,7 +377,11 @@ class NASGenerator(nn.Module):
 
         use_bias = False
         self.n_blocks = n_blocks
-        self.layer_types = ['conv_2d', 'pool_2d']
+        ### CycleGAN: Layer types; n_layers_cell: 5
+        self.layer_types = ['ReflectionPad2d_Conv2d', 'BatchNorm2d', 'InstanceNorm2d', 'ReLU']
+        ### PixelDA: Layer types; n_layers_cell: 5
+        # self.layer_types = ['Conv2d', 'BatchNorm2d', 'ReLU']
+        
         self.n_layers_cell = n_layers_cell
 
         self.module_list = nn.ModuleList()

--- a/models/uni_cycle_gan_model.py
+++ b/models/uni_cycle_gan_model.py
@@ -91,8 +91,8 @@ class UniCycleGANModel(BaseModel):
             self.criterionCycle = torch.nn.L1Loss()
             self.criterionIdt = torch.nn.L1Loss()
             # initialize optimizers; schedulers will be automatically created by function <BaseModel.setup>.
-            self.optimizer_G = torch.optim.Adam(itertools.chain(self.netG_A.parameters()), lr=opt.lr, betas=(opt.beta1, 0.999))
-            self.optimizer_D = torch.optim.Adam(itertools.chain(self.netD_A.parameters()), lr=opt.lr, betas=(opt.beta1, 0.999))
+            self.optimizer_G = torch.optim.Adam(itertools.chain(self.netG_A.parameters(), self.netG_B.parameters()), lr=opt.lr, betas=(opt.beta1, 0.999))
+            self.optimizer_D = torch.optim.Adam(itertools.chain(self.netD_A.parameters(), self.netD_B.parameters()), lr=opt.lr, betas=(opt.beta1, 0.999))
             self.optimizers.append(self.optimizer_G)
             self.optimizers.append(self.optimizer_D)
 

--- a/models/uni_cycle_gan_model.py
+++ b/models/uni_cycle_gan_model.py
@@ -71,9 +71,9 @@ class UniCycleGANModel(BaseModel):
         # The naming is different from those used in the paper.
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         self.netG_A = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                        not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, opt.n_layers_cell)
         self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
-                                       not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
+                                       not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids, opt.n_layers_cell)
 
         if self.isTrain:  # define discriminators
             self.netD_A = networks.define_D(opt.output_nc, opt.ndf, opt.netD,

--- a/models/uni_cycle_gan_model.py
+++ b/models/uni_cycle_gan_model.py
@@ -52,38 +52,34 @@ class UniCycleGANModel(BaseModel):
         """
         BaseModel.__init__(self, opt)
         # specify the training losses you want to print out. The training/test scripts will call <BaseModel.get_current_losses>
-        self.loss_names = ['D_A', 'G_A', 'idt_A']
+        self.loss_names = ['D_A', 'G_A', 'cycle_A', 'idt_A', 'D_B', 'G_B', 'cycle_B', 'idt_B']
         # specify the images you want to save/display. The training/test scripts will call <BaseModel.get_current_visuals>
-        visual_names_A = ['real_A', 'fake_B']
-        visual_names_B = ['real_B']
-        # if self.isTrain and self.opt.lambda_identity > 0.0:  # if identity loss is used, we also visualize idt_B=G_A(B) ad idt_A=G_A(B)
-        #     visual_names_A.append('idt_B')
-        #     visual_names_B.append('idt_A')
+        visual_names_A = ['real_A', 'fake_B', 'rec_A']
+        visual_names_B = ['real_B', 'fake_A', 'rec_B']
+        if self.isTrain and self.opt.lambda_identity > 0.0:  # if identity loss is used, we also visualize idt_B=G_A(B) ad idt_A=G_A(B)
+            visual_names_A.append('idt_B')
+            visual_names_B.append('idt_A')
 
         self.visual_names = visual_names_A + visual_names_B  # combine visualizations for A and B
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>.
         if self.isTrain:
-            self.model_names = ['G_A', 'D_A']
+            self.model_names = ['G_A', 'G_B', 'D_A', 'D_B']
         else:  # during test time, only load Gs
-            self.model_names = ['G_A']
+            self.model_names = ['G_A', 'G_B']
 
         # define networks (both Generators and discriminators)
         # The naming is different from those used in the paper.
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         self.netG_A = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
                                         not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
-        #self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
-        #                                not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
-
-        # print("Parameters from netG_A")
-        # for parameter in self.netG_A.parameters():
-        #     print(parameter.data)
+        self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
+                                       not opt.no_dropout, opt.init_type, opt.init_gain, self.gpu_ids)
 
         if self.isTrain:  # define discriminators
             self.netD_A = networks.define_D(opt.output_nc, opt.ndf, opt.netD,
                                             opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
-            #self.netD_B = networks.define_D(opt.input_nc, opt.ndf, opt.netD,
-            #                                opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
+            self.netD_B = networks.define_D(opt.input_nc, opt.ndf, opt.netD,
+                                           opt.n_layers_D, opt.norm, opt.init_type, opt.init_gain, self.gpu_ids)
 
         if self.isTrain:
             if opt.lambda_identity > 0.0:  # only works when input and output images have the same number of channels
@@ -116,9 +112,9 @@ class UniCycleGANModel(BaseModel):
     def forward(self):
         """Run forward pass; called by both functions <optimize_parameters> and <test>."""
         self.fake_B = self.netG_A(self.real_A)  # G_A(A)
-        #self.rec_A = self.netG_B(self.fake_B)   # G_B(G_A(A))
-        #self.fake_A = self.netG_B(self.real_B)  # G_B(B)
-        #self.rec_B = self.netG_A(self.fake_A)   # G_A(G_B(B))
+        self.rec_A = self.netG_B(self.fake_B)   # G_B(G_A(A))
+        self.fake_A = self.netG_B(self.real_B)  # G_B(B)
+        self.rec_B = self.netG_A(self.fake_A)   # G_A(G_B(B))
 
     def backward_D_basic(self, netD, real, fake):
         """Calculate GAN loss for the discriminator
@@ -163,8 +159,8 @@ class UniCycleGANModel(BaseModel):
             self.idt_A = self.netG_A(self.real_B)
             self.loss_idt_A = self.criterionIdt(self.idt_A, self.real_B) * lambda_B * lambda_idt
             # G_B should be identity if real_A is fed: ||G_B(A) - A||
-            #self.idt_B = self.netG_B(self.real_A)
-            #self.loss_idt_B = self.criterionIdt(self.idt_B, self.real_A) * lambda_A * lambda_idt
+            self.idt_B = self.netG_B(self.real_A)
+            self.loss_idt_B = self.criterionIdt(self.idt_B, self.real_A) * lambda_A * lambda_idt
         else:
             self.loss_idt_A = 0
             self.loss_idt_B = 0
@@ -172,13 +168,13 @@ class UniCycleGANModel(BaseModel):
         # GAN loss D_A(G_A(A))
         self.loss_G_A = self.criterionGAN(self.netD_A(self.fake_B), True)
         # GAN loss D_B(G_B(B))
-        #self.loss_G_B = self.criterionGAN(self.netD_B(self.fake_A), True)
+        self.loss_G_B = self.criterionGAN(self.netD_B(self.fake_A), True)
         # Forward cycle loss || G_B(G_A(A)) - A||
-        #self.loss_cycle_A = self.criterionCycle(self.rec_A, self.real_A) * lambda_A
+        self.loss_cycle_A = self.criterionCycle(self.rec_A, self.real_A) * lambda_A
         # Backward cycle loss || G_A(G_B(B)) - B||
-        #self.loss_cycle_B = self.criterionCycle(self.rec_B, self.real_B) * lambda_B
+        self.loss_cycle_B = self.criterionCycle(self.rec_B, self.real_B) * lambda_B
         # combined loss and calculate gradients
-        self.loss_G = self.loss_G_A + self.loss_idt_A
+        self.loss_G = self.loss_G_A + self.loss_G_B + self.loss_cycle_A + self.loss_cycle_B + self.loss_idt_A + self.loss_idt_B
         self.loss_G.backward()
 
     def optimize_parameters(self):
@@ -186,13 +182,13 @@ class UniCycleGANModel(BaseModel):
         # forward
         self.forward()      # compute fake images and reconstruction images.
         # G_A and G_B
-        self.set_requires_grad([self.netD_A], False)  # Ds require no gradients when optimizing Gs
+        self.set_requires_grad([self.netD_A, self.netD_B], False)  # Ds require no gradients when optimizing Gs
         self.optimizer_G.zero_grad()  # set G_A and G_B's gradients to zero
         self.backward_G()             # calculate gradients for G_A and G_B
         self.optimizer_G.step()       # update G_A and G_B's weights
         # D_A and D_B
-        self.set_requires_grad([self.netD_A], True)
+        self.set_requires_grad([self.netD_A, self.netD_B], True)
         self.optimizer_D.zero_grad()   # set D_A and D_B's gradients to zero
         self.backward_D_A()      # calculate gradients for D_A
-        #self.backward_D_B()      # calculate graidents for D_B
+        self.backward_D_B()      # calculate graidents for D_B
         self.optimizer_D.step()  # update D_A and D_B's weights

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -32,6 +32,7 @@ class BaseOptions():
         parser.add_argument('--ndf', type=int, default=64, help='# of discrim filters in the first conv layer')
         parser.add_argument('--netD', type=str, default='basic', help='specify discriminator architecture [basic | n_layers | pixel]. The basic model is a 70x70 PatchGAN. n_layers allows you to specify the layers in the discriminator')
         parser.add_argument('--netG', type=str, default='resnet_9blocks', help='specify generator architecture [resnet_9blocks | resnet_6blocks | unet_256 | unet_128]')
+        parser.add_argument('--n_layers_cell', type=int, default=5, help='number of layers the trainable cell architecture should have.')
         parser.add_argument('--n_layers_D', type=int, default=3, help='only used if netD==n_layers')
         parser.add_argument('--norm', type=str, default='instance', help='instance normalization or batch normalization [instance | batch | none]')
         parser.add_argument('--init_type', type=str, default='normal', help='network initialization [normal | xavier | kaiming | orthogonal]')

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -35,6 +35,7 @@ class TrainOptions(BaseOptions):
         parser.add_argument('--pool_size', type=int, default=50, help='the size of image buffer that stores previously generated images')
         parser.add_argument('--lr_policy', type=str, default='linear', help='learning rate policy. [linear | step | plateau | cosine]')
         parser.add_argument('--lr_decay_iters', type=int, default=50, help='multiply by a gamma every lr_decay_iters iterations')
+        parser.add_argument('--cell_train_start', type=int, default=50, help='epoch when the cell architecture starts training')
 
         self.isTrain = True
         return parser

--- a/train.py
+++ b/train.py
@@ -24,11 +24,14 @@ from data import create_dataset
 from models import create_model
 from util.visualizer import Visualizer
 
+# add at which epoche the cell architecture starts
+
 if __name__ == '__main__':
     opt = TrainOptions().parse()   # get training options
     dataset = create_dataset(opt)  # create a dataset given opt.dataset_mode and other options
     dataset_size = len(dataset)    # get the number of images in the dataset.
     print('The number of training images = %d' % dataset_size)
+    cell_train_start = opt.cell_train_start
 
     model = create_model(opt)      # create a model given opt.model and other options
     model.setup(opt)               # regular setup: load and print networks; create schedulers
@@ -36,6 +39,10 @@ if __name__ == '__main__':
     total_iters = 0                # the total number of training iterations
 
     for epoch in range(opt.epoch_count, opt.n_epochs + opt.n_epochs_decay + 1):    # outer loop for different epochs; we save the model by <epoch_count>, <epoch_count>+<save_latest_freq>
+        if epoch == cell_train_start:
+            for name, param in model.named_parameters():
+                if name == 'cell_weights':
+                    param.requires_grad = True
         epoch_start_time = time.time()  # timer for entire epoch
         iter_data_time = time.time()    # timer for data loading per iteration
         epoch_iter = 0                  # the number of training iterations in current epoch, reset to 0 every epoch


### PR DESCRIPTION
This PR closes #2 

## models/networks.py
added the NAS_Generator, which creates n layers with trainable cells, which consists of specified layer types and have shared weights.
At the moment the cells do not support any 'skip connections'.

## models/uni_cycle_gan_model.py
reverted back to standart CycleGAN, as well as added options to train as NAS.

## options/base_options.py
added option to define how many layers a cell should have: `n_layers_cell`

## options/train_options.py
added option to define at what epoche the cell training should start: `cell_train_start`

## train.py
now the cell_weights only start training when the `cell_train_start` epoch is reached, as it is done in AutoDeepLab.